### PR TITLE
Improve Connect Four game status messages and add copy ID button

### DIFF
--- a/src/components/SupabaseConnectFour.js
+++ b/src/components/SupabaseConnectFour.js
@@ -45,7 +45,7 @@ const SupabaseConnectFour = () => {
     if (player === PLAYER1) {
       return `Rouge ${isHost ? "(Vous)" : "(Adversaire)"}`;
     } else {
-      return `Jaune ${!isHost ? "(Vous)" : "(Adversaire)"}`;
+      return `Jaune ${!isHost ? "(Vous)" : myPlayer === null ? "(En attente)" : "(Adversaire)"}`;
     }
   };
 

--- a/src/components/SupabaseConnectFour.js
+++ b/src/components/SupabaseConnectFour.js
@@ -35,6 +35,14 @@ const SupabaseConnectFour = () => {
     if (gameOver) {
       return "Match nul !";
     }
+    if (myPlayer === PLAYER2 && currentPlayer === PLAYER1) {
+      return "En attente du premier joueur...";
+    }
+    if (myPlayer === PLAYER1 && !gameOver) {
+      return currentPlayer === myPlayer
+        ? "À votre tour ! (Partie accessible avec l'ID: " + gameId + ")"
+        : "Tour de votre adversaire...";
+    }
     if (currentPlayer === myPlayer) {
       return "À votre tour !";
     }

--- a/src/components/SupabaseConnectFour.js
+++ b/src/components/SupabaseConnectFour.js
@@ -87,6 +87,15 @@ const SupabaseConnectFour = () => {
             <span>
               ID du jeu: <strong>{gameId}</strong>
             </span>
+            {isHost && (
+              <button
+                className="copy-button"
+                onClick={() => navigator.clipboard.writeText(gameId.toString())}
+                title="Copier l'ID du jeu"
+              >
+                📋 Copier ID
+              </button>
+            )}
           </div>
         </div>
 

--- a/src/hooks/useSupabaseGame.js
+++ b/src/hooks/useSupabaseGame.js
@@ -128,7 +128,7 @@ export const useSupabaseGame = () => {
       setCurrentPlayer(game.turn);
       setMyPlayer(PLAYER1); // Host is always player 1
       setIsHost(true);
-      setGameState(GAME_STATES.WAITING_FOR_PLAYER);
+      setGameState(GAME_STATES.PLAYING); // Allow creator to play immediately
 
       // Subscribe to game updates
       subscription.current = gamesAPI.subscribeToGame(

--- a/src/styles/SupabaseGame.css
+++ b/src/styles/SupabaseGame.css
@@ -284,6 +284,14 @@
   box-shadow: 0 2px 10px rgba(76, 175, 80, 0.3);
 }
 
+/* Small copy button for game-id-info */
+.game-id-info .copy-button {
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  border-radius: 15px;
+  box-shadow: 0 1px 5px rgba(76, 175, 80, 0.3);
+}
+
 .copy-button:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 20px rgba(76, 175, 80, 0.4);

--- a/src/styles/SupabaseGame.css
+++ b/src/styles/SupabaseGame.css
@@ -44,7 +44,9 @@
   background: #f8f9fa;
   padding: 8px 15px;
   border-radius: 20px;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
   color: #495057;
   font-size: 0.9rem;
   border: 1px solid #dee2e6;


### PR DESCRIPTION
This pull request enhances the Connect Four game interface with several improvements:

**Status Message Updates:**
- Added specific status message for Player 2 waiting for Player 1
- Enhanced Player 1 status message to include game ID when it's their turn
- Updated player label display logic to show "(En attente)" for pending players

**UI Enhancements:**
- Added copy button for game ID that allows hosts to easily share the game ID
- Updated game-id-info styling to use flexbox layout with proper alignment and spacing
- Added specific styling for the copy button within game-id-info

**Game Flow Improvement:**
- Changed initial game state for creators from WAITING_FOR_PLAYER to PLAYING to allow immediate gameplay

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2d42a70a5e6948b7b9b8bbd63c719cae/curry-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2d42a70a5e6948b7b9b8bbd63c719cae</projectId>-->
<!--<branchName>curry-sanctuary</branchName>-->